### PR TITLE
CVE-2017-11103: Orpheus' Lyre KDC-REP service name validation

### DIFF
--- a/source4/heimdal/lib/krb5/ticket.c
+++ b/source4/heimdal/lib/krb5/ticket.c
@@ -641,8 +641,8 @@ _krb5_extract_ticket(krb5_context context,
     /* check server referral and save principal */
     ret = _krb5_principalname2krb5_principal (context,
 					      &tmp_principal,
-					      rep->kdc_rep.ticket.sname,
-					      rep->kdc_rep.ticket.realm);
+					      rep->enc_part.sname,
+					      rep->enc_part.srealm);
     if (ret)
 	goto out;
     if((flags & EXTRACT_TICKET_ALLOW_SERVER_MISMATCH) == 0){


### PR DESCRIPTION
In _krb5_extract_ticket() the KDC-REP service name must be obtained from
encrypted version stored in 'enc_part' instead of the unencrypted version
stored in 'ticket'.  Use of the unecrypted version provides an
opportunity for successful server impersonation and other attacks.

Identified by Jeffrey Altman, Viktor Duchovni and Nico Williams.

Change-Id: I45ef61e8a46e0f6588d64b5bd572a24c7432547c

BUG: https://bugzilla.samba.org/show_bug.cgi?id=12894
(based on heimdal commit 6dd3eb836bbb80a00ffced4ad57077a1cdf227ea)

Signed-off-by: Andrew Bartlett <abartlet@samba.org>
Reviewed-by: Garming Sam <garming@catalyst.net.nz>
Reviewed-by: Stefan Metzmacher <metze@samba.org>
(cherry picked from commit 9b0972c8e429fee8e15f23ab508a9f0729a4e0b6)

Ticket: #25119