### PR TITLE
Update vfs_zfsacl.c - proposed fix for #26039

### DIFF
--- a/source3/modules/vfs_zfsacl.c
+++ b/source3/modules/vfs_zfsacl.c
@@ -51,8 +51,8 @@ static NTSTATUS zfs_get_nt_acl_common(struct connection_struct *conn,
 	SMB_STRUCT_STAT sbuf;
 	const SMB_STRUCT_STAT *psbuf = NULL;
 	int ret;
-	bool is_dir;
 	bool inherited_present;
+	bool is_dir;
 
 	if (VALID_STAT(smb_fname->st)) {
 		psbuf = &smb_fname->st;
@@ -104,15 +104,6 @@ static NTSTATUS zfs_get_nt_acl_common(struct connection_struct *conn,
 		aceprop.aceFlags = (uint32_t) acebuf[i].a_flags;
 		aceprop.aceMask  = (uint32_t) acebuf[i].a_access_mask;
 		aceprop.who.id   = (uint32_t) acebuf[i].a_who;
-		
-		/*
-		 * Test whether ACL contains any ACEs with the
-		 * inherited flag set. We use this to determine whether
-		 * to set DACL_PROTECTED in the security descriptor.
-		 */
-		if(aceprop.aceFlags & ACE_INHERITED_ACE) {
-			inherited_present = true;
-		}
 
 		/*
 		 * Windows clients expect SYNC on acls to correctly allow
@@ -126,6 +117,16 @@ static NTSTATUS zfs_get_nt_acl_common(struct connection_struct *conn,
 		if (is_dir && (aceprop.aceMask & SMB_ACE4_ADD_FILE)) {
 			aceprop.aceMask |= SMB_ACE4_DELETE_CHILD;
 		}
+
+	
+ 		/*
+ 		 * Test whether ACL contains any ACEs with the
+ 		 * inherited flag set. We use this to determine whether
+ 		 * to set DACL_PROTECTED in the security descriptor.
+ 		 */
+ 		if(aceprop.aceFlags & ACE_INHERITED_ACE) {
+ 			inherited_present = true;
+ 		}
 
 		if(aceprop.aceFlags & ACE_OWNER) {
 			aceprop.flags = SMB_ACE4_ID_SPECIAL;
@@ -144,16 +145,17 @@ static NTSTATUS zfs_get_nt_acl_common(struct connection_struct *conn,
 	}
 
 	/*
-	 * If the ACL doesn't contain any inherited ACEs, then set DACL_PROTECTED 
-	 * in the security descriptor using smb4acl4_set_control_flags() from
-	 * source3/modules/nfs4_acls.c. This makes it so that the "Disable 
-	 * Inheritance" button works in Windows Explorer and prevents resulting 
-	 * ACL from auto-inheriting ACL changes in parent directory.
-	 */
-	if (!inherited_present){
-		smbacl4_set_controlflags(pacl, SEC_DESC_DACL_PROTECTED|SEC_DESC_SELF_RELATIVE);
-	}
-	
+ 	 * If the ACL doesn't contain any inherited ACEs, then set DACL_PROTECTED 
+ 	 * in the security descriptor using smb4acl4_set_control_flags() from
+ 	 * source3/modules/nfs4_acls.c. This makes it so that the "Disable 
+ 	 * Inheritance" button works in Windows Explorer and prevents resulting 
+ 	 * ACL from auto-inheriting ACL changes in parent directory.
+ 	 */
+ 	if (!inherited_present 
+	    && lp_parm_bool(conn->params->service, "zfsacl", "map_dacl_protected", True)){
+ 		smbacl4_set_controlflags(pacl, SEC_DESC_DACL_PROTECTED|SEC_DESC_SELF_RELATIVE);
+ 	}
+
 	*ppacl = pacl;
 	return NT_STATUS_OK;
 }

--- a/source3/modules/vfs_zfsacl.c
+++ b/source3/modules/vfs_zfsacl.c
@@ -52,7 +52,7 @@ static NTSTATUS zfs_get_nt_acl_common(struct connection_struct *conn,
 	const SMB_STRUCT_STAT *psbuf = NULL;
 	int ret;
 	bool is_dir;
-	uint16_t inherited_present;
+	bool inherited_present;
 
 	if (VALID_STAT(smb_fname->st)) {
 		psbuf = &smb_fname->st;
@@ -111,7 +111,7 @@ static NTSTATUS zfs_get_nt_acl_common(struct connection_struct *conn,
 		 * to set DACL_PROTECTED in the security descriptor.
 		 */
 		if(aceprop.aceFlags & ACE_INHERITED_ACE) {
-			inherited_present = 1;
+			inherited_present = true;
 		}
 
 		/*


### PR DESCRIPTION
Set SEC_DESC_DACL_PROTECTED if no ACEs in ACL have "inherited" flag. This makes it so that the "Disable Inheritance" -> "Convert inherited permissions into explicit permissions on this object" button in Windows File Explorer behaves correctly.

This was tested against Samba 4.6.8 in net/samba46 port in FreeBSD.



  