### PR TITLE
Revert "The real samba fix." It was provided as a hot-fix for the

### DIFF
--- a/source3/include/proto.h
+++ b/source3/include/proto.h
@@ -985,7 +985,7 @@ bool lp_use_sendfile(int snum, struct smb_signing_state *signing_state);
 void set_use_sendfile(int snum, bool val);
 void lp_set_mangling_method(const char *new_method);
 bool lp_posix_pathnames(void);
-bool lp_set_posix_pathnames(bool newval);
+void lp_set_posix_pathnames(void);
 enum brl_flavour lp_posix_cifsu_locktype(files_struct *fsp);
 void lp_set_posix_default_cifsx_readwrite_locktype(enum brl_flavour val);
 int lp_min_receive_file_size(void);

--- a/source3/param/loadparm.c
+++ b/source3/param/loadparm.c
@@ -4453,14 +4453,13 @@ bool lp_posix_pathnames(void)
 }
 
 /*******************************************************************
- Set posix pathnames to new value. Returns old value.
+ Change everything needed to ensure POSIX pathname processing (currently
+ not much).
 ********************************************************************/
 
-bool lp_set_posix_pathnames(bool newval)
+void lp_set_posix_pathnames(void)
 {
-	bool oldval = posix_pathnames;
-	posix_pathnames = newval;
-	return oldval;
+	posix_pathnames = true;
 }
 
 /*******************************************************************

--- a/source3/smbd/close.c
+++ b/source3/smbd/close.c
@@ -170,7 +170,6 @@ NTSTATUS delete_all_streams(connection_struct *conn,
 	unsigned int num_streams = 0;
 	TALLOC_CTX *frame = talloc_stackframe();
 	NTSTATUS status;
-	bool saved_posix_pathnames;
 
 	status = vfs_streaminfo(conn, NULL, smb_fname, talloc_tos(),
 				&num_streams, &stream_info);
@@ -194,13 +193,6 @@ NTSTATUS delete_all_streams(connection_struct *conn,
 		TALLOC_FREE(frame);
 		return NT_STATUS_OK;
 	}
-
-	/*
-	 * Any stream names *must* be treated as Windows
-	 * pathnames, even if we're using UNIX extensions.
-	 */
-
-	saved_posix_pathnames = lp_set_posix_pathnames(false);
 
 	for (i=0; i<num_streams; i++) {
 		int res;
@@ -237,8 +229,6 @@ NTSTATUS delete_all_streams(connection_struct *conn,
 	}
 
  fail:
-
-	(void)lp_set_posix_pathnames(saved_posix_pathnames);
 	TALLOC_FREE(frame);
 	return status;
 }

--- a/source3/smbd/open.c
+++ b/source3/smbd/open.c
@@ -4450,7 +4450,6 @@ static NTSTATUS open_streams_for_delete(connection_struct *conn,
 	unsigned int num_streams = 0;
 	TALLOC_CTX *frame = talloc_stackframe();
 	NTSTATUS status;
-	bool saved_posix_pathnames;
 
 	status = vfs_streaminfo(conn, NULL, smb_fname, talloc_tos(),
 				&num_streams, &stream_info);
@@ -4482,13 +4481,6 @@ static NTSTATUS open_streams_for_delete(connection_struct *conn,
 		status = NT_STATUS_NO_MEMORY;
 		goto fail;
 	}
-
-	/*
-	 * Any stream names *must* be treated as Windows
-	 * pathnames, even if we're using UNIX extensions.
-	 */
-
-	saved_posix_pathnames = lp_set_posix_pathnames(false);
 
 	for (i=0; i<num_streams; i++) {
 		struct smb_filename *smb_fname_cp;
@@ -4561,8 +4553,6 @@ static NTSTATUS open_streams_for_delete(connection_struct *conn,
 	}
 
  fail:
-
-	(void)lp_set_posix_pathnames(saved_posix_pathnames);
 	TALLOC_FREE(frame);
 	return status;
 }

--- a/source3/smbd/trans2.c
+++ b/source3/smbd/trans2.c
@@ -4269,7 +4269,7 @@ static void call_trans2setfsinfo(connection_struct *conn,
 
 			/* Here is where we must switch to posix pathname processing... */
 			if (xconn->smb1.unix_info.client_cap_low & CIFS_UNIX_POSIX_PATHNAMES_CAP) {
-				(void)lp_set_posix_pathnames(true);
+				lp_set_posix_pathnames();
 				mangle_change_to_posix();
 			}
 


### PR DESCRIPTION
Samba 4.4.* and downwards, newer versions should handle this natively

See: https://bugzilla.samba.org/show_bug.cgi?id=12021

This reverts commit 29e6f476f1b3e673667de675b765779f5745d4bb.

(cherry picked from commit 5918cd9434030d0d16b3352ce67865592513a63e)
Signed-off-by: Timur I. Bakeyev <timur@iXsystems.com>