### PR TITLE
Fix netbios aliases for HA

### DIFF
--- a/docs-xml/smbdotconf/winbind/winbindnetbiosaliasspn.xml
+++ b/docs-xml/smbdotconf/winbind/winbindnetbiosaliasspn.xml
@@ -1,0 +1,15 @@
+<samba:parameter name="winbind netbios alias spn"
+                 context="G"
+                 type="boolean"
+                 xmlns:samba="http://www.samba.org/samba/DTD/samba-doc">
+<description>
+
+        <para>This parameter is designed to control whether netbios alias should
+        be added to the spn during domain join.                                                  
+        </para>
+
+</description>
+
+<value type="default">yes</value>
+<value type="example">no</value>
+</samba:parameter>

--- a/source3/libnet/libnet_join.c
+++ b/source3/libnet/libnet_join.c
@@ -531,7 +531,7 @@ static ADS_STATUS libnet_join_set_machine_spn(TALLOC_CTX *mem_ctx,
 	}
 
 	netbios_aliases = lp_netbios_aliases();
-	if (netbios_aliases != NULL) {
+	if (netbios_aliases != NULL && lp_winbind_netbios_alias_spn()) {
 		for (; *netbios_aliases != NULL; netbios_aliases++) {
 			/*
 			 * Add HOST/NETBIOSNAME

--- a/source3/param/loadparm.c
+++ b/source3/param/loadparm.c
@@ -717,6 +717,7 @@ static void init_globals(struct loadparm_context *lp_ctx, bool reinit_globals)
 	Globals.create_krb5_conf = true;
 	Globals.include_system_krb5_conf = true;
 	Globals._winbind_max_domain_connections = 1;
+	Globals.winbind_netbios_alias_spn = true;
 	Globals.ads_dns_update = 1;
 
 	/* hostname lookups can be very expensive and are broken on


### PR DESCRIPTION
Upstream samba changed behavior regarding netbios aliases when joining an AD domain. This currently breaks AD on HA. These patches make the new behavior configurable so that we can choose to restore former behavior as needed on HA systems.