### PR TITLE
If ADS, remove FILE_ATTRIBUTE_DIRECTORY

### DIFF
--- a/source3/smbd/dosmode.c
+++ b/source3/smbd/dosmode.c
@@ -395,6 +395,11 @@ NTSTATUS get_ea_dos_attribute(connection_struct *conn,
 	if (S_ISDIR(smb_fname->st.st_ex_mode)) {
 		dosattr |= FILE_ATTRIBUTE_DIRECTORY;
 	}
+	
+	if (is_ntfs_stream_smb_fname(smb_fname)) {
+		dosattr &= ~(FILE_ATTRIBUTE_DIRECTORY);
+	}
+
 	/* FILE_ATTRIBUTE_SPARSE is valid on get but not on set. */
 	*pattr |= (uint32_t)(dosattr & (SAMBA_ATTRIBUTES_MASK|FILE_ATTRIBUTE_SPARSE));
 


### PR DESCRIPTION
get_ea_dos_attribute() can incorrectly return FILE_ATTRIBUTE_DIRECTORY in dosmode for alternate datastreams that are on a directory. This causes Windows File Explorer on Windows 7 to throw an "invalid ms dos function" error.