### PR TITLE
fix corruption of first byte in AFP_AfpInfo stream/xattr

### DIFF
--- a/source3/modules/vfs_streams_xattr.c
+++ b/source3/modules/vfs_streams_xattr.c
@@ -541,7 +541,7 @@ static int streams_xattr_open(vfs_handle_struct *handle,
 		ret = SMB_VFS_SETXATTR(fsp->conn,
 				       smb_fname,
 				       xattr_name,
-				       &null, sizeof(null),
+				       &null, 0,
 				       flags & O_EXCL ? XATTR_CREATE : 0);
 		if (ret != 0) {
 			goto fail;


### PR DESCRIPTION
Ticket #34134

See also FreeBSD bug ticket here: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=228462

Background:
====================
Struct for AFP_AfpInfo is as follows:
```
typedef struct {
/*Ofs*/
/*  0*/    le32 signature;        /* Must be "AFP\0". */
/*  4*/    le32 version;        /* Must be 0x00010000. */
/*  8*/    le32 fileid;        /* This is the inode number as returned by the
                   AFP connection.  For some reason this is not
                   the same as the underlying NTFS inode
                   number.  Need to set this to zero on create,
                   preserve it on write, and ignore it on
                   read. */
/* 12*/    le32 backup_time;    /* Backup time for the file/dir in AppleDouble
                   time format (see above). */
/* 16*/    FINDER_INFO finder_info;/* Finder Info (32 bytes, see above). */
/* 48*/    PRODOS_INFO prodos_info;/* ProDOS Info (6 bytes, see above). */
/* 54*/ u8 reserved[6];        /* Reserved. */
/* sizeof() = 60 (0x3c) bytes */
```
```
root@cat_herder:/mnt/dozer/SOFIA_PHOTOS # getextattr -q user 'DosStream.AFP_AfpInfo:$DATA' 
Finder\ Refresh.app/ | hexdump -C
00000000  00 46 50 00 00 00 01 00  00 00 00 00 80 00 00 00  |,FP.............|
00000010  50 4c 41 50 6c 74 61 70  04 10 00 00 00 00 00 00  |PLAPltap........|
00000020  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000030
```

After new streams_xattr:

```
00000000  00 46 50 00 00 00 01 00  00 00 00 00 00 00 00 80  |.FP.............|
00000010  50 4c 41 50 6c 74 61 70  04 10 00 00 00 00 00 00  |PLAPltap........|
00000020  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000030
```
====================
Ralph's explanation is as follows:
>vfs_streams_xattr to not read and write an additional trailing byte (cf the comment lines containing "// ? -1" in the patch), but when creating a stream the trailing byte is still stored (cf streams_xattr_open() the code after the comment "Darn, xattrs need at least 1 byte").
>
>Due to a vicious interaction with a bug that is present in the latest macOS 10.13.4 (not sure about earlier versions) what happens is this:
>
>- the client send a request to create a stream "file:AFP_AfpInfo"
>- the server creates the xattr for the stream and writes a 0 byte
>- the client sends a request to read 60 bytes at offset 0 from the stream
>- the server returns a one byte sized buffer containing a 0 instead of returning nread=0 and status=NT_STATUS_END_OF_FILE
>- the final nail in the coffin is that the client, when writing the AFP_AfpInfo blob whos first four byte start with a magic string "AFP" takes the 0 byte the server returned and overwrites the first byte of the magic string
>
>The fix for this twofold: first, we must fix vfs_streams_xattr to not store an initial zero byte when creating an xattr. Second, we must prepare vfs_fruit to allow such broken AFP_AfpInfo blobs, otherwise users who adding vfs_fruit run into the issue that vfs_fruit has a builtin check for the magic string..."

Malformed signatures may cause undefined client behavior.