### PR TITLE
vfs_fruit: Fix a leak of "br_lck"

### DIFF
--- a/source3/modules/vfs_fruit.c
+++ b/source3/modules/vfs_fruit.c
@@ -1971,7 +1971,6 @@ static NTSTATUS fruit_check_access(vfs_handle_struct *handle,
 				   uint32_t deny_mode)
 {
 	NTSTATUS status = NT_STATUS_OK;
-	struct byte_range_lock *br_lck = NULL;
 	bool open_for_reading, open_for_writing, deny_read, deny_write;
 	off_t off;
 	bool have_read = false;
@@ -2029,6 +2028,8 @@ static NTSTATUS fruit_check_access(vfs_handle_struct *handle,
 
 		/* Set locks */
 		if ((access_mask & FILE_READ_DATA) && have_read) {
+			struct byte_range_lock *br_lck = NULL;
+
 			off = access_to_netatalk_brl(fork_type, FILE_READ_DATA);
 			br_lck = do_lock(
 				handle->conn->sconn->msg_ctx, fsp,
@@ -2036,13 +2037,16 @@ static NTSTATUS fruit_check_access(vfs_handle_struct *handle,
 				READ_LOCK, POSIX_LOCK, false,
 				&status, NULL);
 
+			TALLOC_FREE(br_lck);
+
 			if (!NT_STATUS_IS_OK(status))  {
 				return status;
 			}
-			TALLOC_FREE(br_lck);
 		}
 
 		if ((deny_mode & DENY_READ) && have_read) {
+			struct byte_range_lock *br_lck = NULL;
+
 			off = denymode_to_netatalk_brl(fork_type, DENY_READ);
 			br_lck = do_lock(
 				handle->conn->sconn->msg_ctx, fsp,
@@ -2050,10 +2054,11 @@ static NTSTATUS fruit_check_access(vfs_handle_struct *handle,
 				READ_LOCK, POSIX_LOCK, false,
 				&status, NULL);
 
+			TALLOC_FREE(br_lck);
+
 			if (!NT_STATUS_IS_OK(status)) {
 				return status;
 			}
-			TALLOC_FREE(br_lck);
 		}
 	}
 
@@ -2079,6 +2084,8 @@ static NTSTATUS fruit_check_access(vfs_handle_struct *handle,
 
 		/* Set locks */
 		if ((access_mask & FILE_WRITE_DATA) && have_read) {
+			struct byte_range_lock *br_lck = NULL;
+
 			off = access_to_netatalk_brl(fork_type, FILE_WRITE_DATA);
 			br_lck = do_lock(
 				handle->conn->sconn->msg_ctx, fsp,
@@ -2086,13 +2093,15 @@ static NTSTATUS fruit_check_access(vfs_handle_struct *handle,
 				READ_LOCK, POSIX_LOCK, false,
 				&status, NULL);
 
+			TALLOC_FREE(br_lck);
+
 			if (!NT_STATUS_IS_OK(status)) {
 				return status;
 			}
-			TALLOC_FREE(br_lck);
-
 		}
 		if ((deny_mode & DENY_WRITE) && have_read) {
+			struct byte_range_lock *br_lck = NULL;
+
 			off = denymode_to_netatalk_brl(fork_type, DENY_WRITE);
 			br_lck = do_lock(
 				handle->conn->sconn->msg_ctx, fsp,
@@ -2100,14 +2109,13 @@ static NTSTATUS fruit_check_access(vfs_handle_struct *handle,
 				READ_LOCK, POSIX_LOCK, false,
 				&status, NULL);
 
+			TALLOC_FREE(br_lck);
+
 			if (!NT_STATUS_IS_OK(status)) {
 				return status;
 			}
-			TALLOC_FREE(br_lck);
 		}
 	}
-
-	TALLOC_FREE(br_lck);
 
 	return status;
 }


### PR DESCRIPTION
Fix a panic if fruit_access_check detects a locking conflict.

do_lock() returns a valid br_lck even in case of a locking conflict.
Not free'ing it leads to a invalid lock order panic later, because
"br_lck" corresponds to a dbwrap lock on brlock.tdb.

BUG: https://bugzilla.samba.org/show_bug.cgi?id=13584

Signed-off-by: Volker Lendecke <vl@samba.org>
Reviewed-by: Jeremy Allison <jra@samba.org>
(cherry picked from commit 51d57073798f76ec4f1261945e0ba779b2530009)