### PR TITLE
Multiple CVE Fixes in Samba 4.7 (11.1-stable)

### DIFF
--- a/python/samba/tests/dns.py
+++ b/python/samba/tests/dns.py
@@ -798,6 +798,30 @@ class TestComplexQueries(DNSTest):
         self.assertEquals(response.answers[1].name, name2)
         self.assertEquals(response.answers[1].rdata, name0)
 
+    def test_cname_loop(self):
+        cname1 = "cnamelooptestrec." + self.get_dns_domain()
+        cname2 = "cnamelooptestrec2." + self.get_dns_domain()
+        cname3 = "cnamelooptestrec3." + self.get_dns_domain()
+        self.make_dns_update(cname1, cname2, dnsp.DNS_TYPE_CNAME)
+        self.make_dns_update(cname2, cname3, dnsp.DNS_TYPE_CNAME)
+        self.make_dns_update(cname3, cname1, dnsp.DNS_TYPE_CNAME)
+
+        p = self.make_name_packet(dns.DNS_OPCODE_QUERY)
+        questions = []
+
+        q = self.make_name_question(cname1,
+                                    dns.DNS_QTYPE_A,
+                                    dns.DNS_QCLASS_IN)
+        questions.append(q)
+        self.finish_name_packet(p, questions)
+
+        (response, response_packet) =\
+            self.dns_transaction_udp(p, host=self.server_ip)
+
+        max_recursion_depth = 20
+        self.assertEquals(len(response.answers), max_recursion_depth)
+
+
 class TestInvalidQueries(DNSTest):
     def setUp(self):
         super(TestInvalidQueries, self).setUp()

--- a/selftest/knownfail.d/dns
+++ b/selftest/knownfail.d/dns
@@ -45,3 +45,9 @@ samba.tests.dns.__main__.TestSimpleQueries.test_qtype_all_query\(rodc:local\)
 
 # The SOA override should not pass against the RODC, it must not overstamp
 samba.tests.dns.__main__.TestSimpleQueries.test_one_SOA_query\(rodc:local\)
+
+#
+# rodc and vampire_dc require signed dns updates, so the test setup
+# fails, but the test does run on fl2003dc
+^samba.tests.dns.__main__.TestComplexQueries.test_cname_loop\(rodc:local\)
+^samba.tests.dns.__main__.TestComplexQueries.test_cname_loop\(vampire_dc:local\)

--- a/source4/dns_server/dns_query.c
+++ b/source4/dns_server/dns_query.c
@@ -40,6 +40,7 @@
 
 #undef DBGC_CLASS
 #define DBGC_CLASS DBGC_DNS
+#define MAX_Q_RECURSION_DEPTH 20
 
 struct forwarder_string {
 	const char *forwarder;
@@ -469,6 +470,11 @@ static struct tevent_req *handle_dnsrpcrec_send(
 	}
 	state->answers = answers;
 	state->nsrecs = nsrecs;
+
+	if (talloc_array_length(*answers) >= MAX_Q_RECURSION_DEPTH) {
+		tevent_req_done(req);
+		return tevent_req_post(req, ev);
+	}
 
 	resolve_cname = ((rec->wType == DNS_TYPE_CNAME) &&
 			 ((question->question_type == DNS_QTYPE_A) ||

--- a/source4/kdc/db-glue.c
+++ b/source4/kdc/db-glue.c
@@ -2578,10 +2578,10 @@ samba_kdc_check_pkinit_ms_upn_match(krb5_context context,
 	 * comparison */
 	if (!(orig_sid && target_sid && dom_sid_equal(orig_sid, target_sid))) {
 		talloc_free(mem_ctx);
-#ifdef KRB5_KDC_ERR_CLIENT_NAME_MISMATCH /* Heimdal */
-		return KRB5_KDC_ERR_CLIENT_NAME_MISMATCH;
-#elif defined(KRB5KDC_ERR_CLIENT_NAME_MISMATCH) /* MIT */
+#if defined(KRB5KDC_ERR_CLIENT_NAME_MISMATCH) /* MIT */
 		return KRB5KDC_ERR_CLIENT_NAME_MISMATCH;
+#else /* Heimdal (where this is an enum) */
+		return KRB5_KDC_ERR_CLIENT_NAME_MISMATCH;
 #endif
 	}
 

--- a/source4/ldap_server/ldap_server.c
+++ b/source4/ldap_server/ldap_server.c
@@ -669,12 +669,12 @@ static void ldapsrv_call_writev_start(struct ldapsrv_call *call)
 		ret = data_blob_append(call, &blob, b.data, b.length);
 		data_blob_free(&b);
 
-		talloc_set_name_const(blob.data, "Outgoing, encoded LDAP packet");
-
 		if (!ret) {
 			ldapsrv_terminate_connection(conn, "data_blob_append failed");
 			return;
 		}
+
+		talloc_set_name_const(blob.data, "Outgoing, encoded LDAP packet");
 
 		DLIST_REMOVE(call->replies, call->replies);
 	}

--- a/testprogs/blackbox/test_pkinit_heimdal.sh
+++ b/testprogs/blackbox/test_pkinit_heimdal.sh
@@ -75,9 +75,17 @@ testit "STEP1 kinit with pkinit (name specified) " $samba4kinit $enctype --reque
 testit "STEP1 kinit renew ticket (name specified)" $samba4kinit --request-pac -R  || failed=`expr $failed + 1`
 test_smbclient "STEP1 Test login with kerberos ccache (name specified)" 'ls' "$unc" -k yes || failed=`expr $failed + 1`
 
+testit_expect_failure "STEP1 kinit with pkinit (wrong name specified) " $samba4kinit $enctype --request-pac --renewable $PKUSER not$USERNAME@$REALM || failed=`expr $failed + 1`
+
+testit_expect_failure "STEP1 kinit with pkinit (wrong name specified 2) " $samba4kinit $enctype --request-pac --renewable $PKUSER $SERVER@$REALM || failed=`expr $failed + 1`
+
 testit "STEP1 kinit with pkinit (enterprise name specified)" $samba4kinit $enctype --request-pac --renewable $PKUSER --enterprise $USERNAME@$REALM || failed=`expr $failed + 1`
 testit "STEP1 kinit renew ticket (enterprise name specified)" $samba4kinit --request-pac -R  || failed=`expr $failed + 1`
 test_smbclient "STEP1 Test login with kerberos ccache (enterprise name specified)" 'ls' "$unc" -k yes || failed=`expr $failed + 1`
+
+testit_expect_failure "STEP1 kinit with pkinit (wrong enterprise name specified) " $samba4kinit $enctype --request-pac --renewable $PKUSER --enterprise not$USERNAME@$REALM || failed=`expr $failed + 1`
+
+testit_expect_failure "STEP1 kinit with pkinit (wrong enterprise name specified 2) " $samba4kinit $enctype --request-pac --renewable $PKUSER --enterprise $SERVER$@$REALM || failed=`expr $failed + 1`
 
 testit "STEP1 kinit with pkinit (enterprise name in cert)" $samba4kinit $enctype --request-pac --renewable $PKUSER --pk-enterprise || failed=`expr $failed + 1`
 testit "STEP1 kinit renew ticket (enterprise name in cert)" $samba4kinit --request-pac -R  || failed=`expr $failed + 1`

--- a/wscript
+++ b/wscript
@@ -51,6 +51,14 @@ def set_options(opt):
                    help='build Samba with system MIT Kerberos. ' +
                         'You may specify list of paths where Kerberos is installed (e.g. /usr/local /usr/kerberos) to search krb5-config',
                    action='callback', callback=system_mitkrb5_callback, dest='with_system_mitkrb5', default=False)
+
+    opt.add_option('--with-experimental-mit-ad-dc',
+                   help='Enable the experimental MIT Kerberos-backed AD DC.  ' +
+                   'Note that security patches are not issued for this configuration',
+                   action='store_true',
+                   dest='with_experimental_mit_ad_dc',
+                   default=False)
+
     opt.add_option('--with-system-mitkdc',
                    help=('Specify the path to the krb5kdc binary from MIT Kerberos'),
                    type="string",
@@ -168,7 +176,16 @@ def configure(conf):
         conf.DEFINE('AD_DC_BUILD_IS_ENABLED', 1)
 
     if Options.options.with_system_mitkrb5:
+        if not Options.options.with_experimental_mit_ad_dc and \
+           not Options.options.without_ad_dc:
+            raise Utils.WafError('The MIT Kerberos build of Samba as an AD DC ' +
+                                 'is experimental. Therefore '
+                                 '--with-system-mitkrb5 requires either ' +
+                                 '--with-experimental-mit-ad-dc or ' +
+                                 '--without-ad-dc')
+
         conf.PROCESS_SEPARATE_RULE('system_mitkrb5')
+
     if not (Options.options.without_ad_dc or Options.options.with_system_mitkrb5):
         conf.DEFINE('AD_DC_BUILD_IS_ENABLED', 1)
 


### PR DESCRIPTION
tkt: 59958
o CVE-2018-14629 (Unprivileged adding of CNAME record causing loop in AD Internal DNS server)
o CVE-2018-16841 (Double-free in Samba AD DC KDC with PKINIT)
o CVE-2018-16851 (NULL pointer de-reference in Samba AD DC LDAP server)
o CVE-2018-16853 (Samba AD DC S4U2Self crash in experimental MIT Kerberos configuration (unsupported))